### PR TITLE
Add logic to remove title repetition on home page

### DIFF
--- a/layouts/partials/meta/standard.html
+++ b/layouts/partials/meta/standard.html
@@ -2,11 +2,21 @@
 <meta http-equiv="content-type" content="text/html">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
+{{/* Easiest way to keep the site title from repeating on the home page */}}
+{{- if .IsHome -}}
+<title itemprop="name">{{ .Site.Title }}</title>
+<meta property="og:title" content="{{ .Site.Title }}" />
+<meta name="twitter:title" content="{{ .Site.Title }}" />
+<meta itemprop="name" content="{{ .Site.Title }}" />
+<meta name="application-name" content="{{ .Site.Title }}" />
+{{- else -}}
 <title itemprop="name">{{ .Title }} | {{ .Site.Title }}</title>
+<meta name="application-name" content=" {{ .Site.Title }}" />
 <meta property="og:title" content="{{ .Title }} | {{ .Site.Title }}" />
 <meta name="twitter:title" content="{{ .Title }} | {{ .Site.Title }}" />
 <meta itemprop="name" content="{{ .Title }} | {{ .Site.Title }}" />
 <meta name="application-name" content="{{ .Title }} | {{ .Site.Title }}" />
+{{ end }}
 <meta property="og:site_name" content="{{ .Site.Params.sitename }}" />
 
 {{/*  Define empty variable description  */}}


### PR DESCRIPTION
Easiest way to keep the title from repeating on the home page. String concatenation in Hugo templating is prettttttty gnarly stuff.