### PR TITLE
Add altDescription option for params.author to describe an avatar

### DIFF
--- a/layouts/partials/bio.html
+++ b/layouts/partials/bio.html
@@ -1,5 +1,11 @@
 {{ $avatar_img := .Site.Params.author.avatar }}
 {{ $avatar_img_alt := .Site.Params.author.name }}
+
+{{/* If an alt description of the avatar is provided, use it */}}
+{{ if .Site.Params.author.altDescription }}
+  {{ $avatar_img_alt = .Site.Params.author.altDescription }}
+{{ end }}
+
 {{ $image := resources.Get $avatar_img }}
 <div class="author">
     {{ with $image }}


### PR DESCRIPTION
Lets you use `altDescription` under `params.author` to better describe what's in the author avatar. Defaults to the author name when not present.